### PR TITLE
Forwarded JSOn should have lowercase keys

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,45 @@
+name: Go
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    name: "Build"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: ['1.15', '1.16', '1.17']
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go }}
+
+      - name: Go build (source)
+        run: make
+
+      - name: Go build (tests)
+        run: make test
+
+      - name: Go lint
+        run: |
+          if [ $(gofmt -l src/* | wc -l) -gt 0 ]; then
+            gofmt -d src/*
+            exit 1
+          fi
+
+      - name: Go vet
+        run: make vet
+
+  lint-code:
+    name: Lint code
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v2.5.1

--- a/Makefile
+++ b/Makefile
@@ -25,3 +25,9 @@ distribution-tarball:
 		--transform s/^\./$(PKGNAME)-$(VERSION)/ \
 		. && mv /tmp/$(PKGNAME)-$(VERSION).tar.gz .
 	rm -rf ./vendor
+
+test:
+	go test *.go
+
+vet:
+	go vet *.go

--- a/server_test.go
+++ b/server_test.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	pb "github.com/redhatinsights/yggdrasil/protocol"
+	"testing"
+)
+
+func TestDispatch(t *testing.T) {
+	input := &pb.Data{}
+
+	got := jsonData(input)
+	want := "{\"response_to\":\"\",\"metadata\":null,\"content\":null,\"directive\":\"\"}"
+
+	if string(got) != want {
+		t.Fatalf(`Got: %q, Wanted: %q`, string(got), want)
+	}
+}


### PR DESCRIPTION
Golang uses capitalized variable names for JSON that is sent into
the yggdrasil service. When this data is forwarded, it needs to be
converted back to the proper JSON format to retain the same structure.